### PR TITLE
Raise memory limits

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -19,12 +19,12 @@ variable "cpu_limit" {
 
 variable "mem_limit" {
   type    = number
-  default = 64
+  default = 128
 }
 
 variable "mem_reservation" {
   type    = number
-  default = 32
+  default = 96
 }
 
 variable "container_restart_policy_enabled" {


### PR DESCRIPTION
We have seen that, following a recent release, this application has been killed, repeatedly, because it's "out of memory"

This commit raises the ECS memory limits.  Note that the EC2 server onto which this is deployed has around 2GB of free memory, and so this small increase should not be problematic.