### PR TITLE
Make exit_non_zero exit

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -27,9 +27,14 @@ function image_base_sha()
   docker run --rm $(image_name) sh -c 'echo ${CYBER_DOJO_START_POINTS_BASE_SHA}'
 }
 
+# Ends the script, non-zero. Not kill -INT $$: a signal is a request, and four
+# of the scripts sourcing this file trap INT to remove a temp dir. Those
+# handlers do not exit, so bash ran the handler and then carried on from the
+# next statement - a guard reporting a problem left the script running and
+# exiting 0. exit cannot be declined; the EXIT trap still runs the cleanup.
 function exit_non_zero()
 {
-  kill -INT $$
+  exit 42
 }
 
 function stderr()


### PR DESCRIPTION
  A signal is a request. exit_non_zero sent SIGINT to the script's own pid, but
  four of the scripts sourcing this file trap INT to remove a temp dir, and those
  handlers do not exit - so bash ran the handler and carried on from the next
  statement. Every guard built on this reported its problem and let the script run
  on to exit 0: the two wrappers here, and the assert_equal calls in build_image.sh
  and both build_from_one_*_start_point.sh.

  exit cannot be declined, and the EXIT trap still runs, so the temp dir is still
  cleaned up. 42 matches what creator and dashboard use.